### PR TITLE
Support verilator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+*.log
+gpio0-read
+gpio0-write

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ The benchmarking tool is separated into two rust projects:
 
 ## Benchmarking Suite
 
-### Usage
-
-The benchmarking suite can be built using `cargo build`.
-
-To run or test the suite with the qemu emulator use `cargo run` or `cargo test` respectively.
-
 ### Structure
 
 The suite is written to run on a single `riscv32imc` [Ibex Core](https://github.com/lowRISC/ibex).
@@ -21,3 +15,23 @@ The code of the benchmarking suite uses two main abstractions:
 
 - `suite/src/modules/`: Modules that communicate with HWIP (ex. UART, future opentitan HWIPs)
 - `suite/src/platform/`: Combines the modules to create different platforms to compile for (ex. qemu virt board, FPGA board)
+
+### Usage
+
+The benchmarking suite can be built using `cargo build`.
+
+**Running/Testing using the Qemu emulator:**
+
+Simply use `cargo run-qemu` or `cargo test-qemu`. \
+The serial-output of the uart will be printed to stdout by default. Using `-s pty` as an argument a pty is used instead.
+
+**Running/Testing using Opentitan & Verilator:**
+1. Use the Opentitan project to build the earlgrey chip, the test_rom and the otp_img, for the verilator target.
+2. Set the environment variables `VERILATOR_SIM`, `VERILATOR_ROM`, `VERILATOR_OTP` to the resulting artifacts.
+   ```console
+   export VERILATOR_SIM=/path/to/opentitan/build-bin/hw/top_earlgrey/Vchip_earlgrey_verilator
+   export VERILATOR_ROM=/path/to/opentitan/build-bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem
+   export VERILATOR_OTP=/path/to/opentitan/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+   ```
+3. Use `cargo run-verilator` or `cargo test-verilator`. \
+   Note that the verilator test does not stop execution, the result can only be determined by reading from the pty. 

--- a/suite/.cargo/config.toml
+++ b/suite/.cargo/config.toml
@@ -4,17 +4,13 @@ rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]
 
-runner = [ 
-  "qemu-system-riscv32",
-  "-M", "virt",
-  "-cpu", "rv32",
-  "-smp", "1",
-  "-m", "64K",
-  "-display", "none",
-  "-bios", "none",
-  "-serial", "stdio",
-  "-kernel", # Cargo will pass the path to the file as last argument
-]
+runner = ".cargo/runner.sh"
 
 [build]
 target = "riscv32imc-unknown-none-elf"
+
+[alias]
+run-qemu = "run --no-default-features --features platform_qemu_virt -- -q"
+test-qemu = "test --no-default-features --features platform_qemu_virt -- -q"
+run-verilator = "run --no-default-features --features platform_verilator_earlgrey -- -v"
+test-verilator = "test --no-default-features --features platform_verilator_earlgrey -- -v"

--- a/suite/.cargo/runner.sh
+++ b/suite/.cargo/runner.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Utility Script for running the benchmarking suite
+
+# Variables for styling output:
+FNT_BOLD=$(tput bold 2>/dev/null)
+FNT_NORMAL=$(tput sgr0 2>/dev/null)
+FNT_RED=$(tput setaf 1 2>/dev/null)
+FNT_GREEN=$(tput setaf 2 2>/dev/null)
+
+# Variables
+USE_SIMULATOR="none"
+SERIAL="stdio"
+KERNEL=$1
+
+shift
+while getopts "s:vq" arg
+do
+    case ${arg} in
+        s) # sets a custom serial argument if possible
+            SERIAL=$OPTARG
+            ;;
+        v) # specify to use verilator
+            USE_SIMULATOR="verilator"
+            ;;
+        q) # specify to use qemu 
+            USE_SIMULATOR="qemu"
+            ;;
+        ?)
+            echo "${FNT_BOLD}${FNT_RED}runner-error${FNT_NORMAL}: Invalid arguments"
+            exit 1
+            ;;
+    esac
+done
+
+case "$USE_SIMULATOR" in
+    "verilator")
+        echo "       ${FNT_BOLD}${FNT_GREEN}using${FNT_NORMAL} verilator"
+        if [[ -z "$VERILATOR_SIM" ]]; then
+            echo "${FNT_BOLD}${FNT_RED}runner-error${FNT_NORMAL}: set up the VERILATOR_SIM environment variable to point to the chip simulator binary"
+            USE_SIMULATOR="none"
+        fi
+        if [[ -z "$VERILATOR_ROM" ]]; then
+            echo "${FNT_BOLD}${FNT_RED}runner-error${FNT_NORMAL}: set up the VERILATOR_ROM environment variable to point to the file that should be loaded into rom"
+            USE_SIMULATOR="none"
+        fi
+        if [[ -z "$VERILATOR_OTP" ]]; then
+            echo "${FNT_BOLD}${FNT_RED}runner-error${FNT_NORMAL}: set up the VERILATOR_OTP environment variable to point to the file that should be loaded into otp"
+            USE_SIMULATOR="none"
+        fi
+
+        if [[ $USE_SIMULATOR == "verilator" ]]; then
+            cp $KERNEL $KERNEL.elf
+            $VERILATOR_SIM --meminit=rom,$VERILATOR_ROM --meminit=flash,$KERNEL.elf --meminit=otp,$VERILATOR_OTP
+        else
+            exit 2
+        fi
+        ;;
+    "qemu")
+        echo "       ${FNT_BOLD}${FNT_GREEN}using${FNT_NORMAL} qemu"
+        qemu-system-riscv32 \
+            -M virt \
+            -cpu rv32 \
+            -smp 1 \
+            -m 64K \
+            -display none \
+            -bios none \
+            -serial $SERIAL \
+            -kernel $KERNEL
+        ;;
+    *)
+        echo "use 'cargo run-<arch>' or 'cargo test-<arch>' instead, supported archs:"
+        echo "  qemu"
+        echo "  verilator"
+        exit 2
+        ;;
+esac

--- a/suite/Cargo.toml
+++ b/suite/Cargo.toml
@@ -10,5 +10,6 @@ bitflags = "^1.3.2"
 linked_list_allocator = { version = "^0.9.1", default-features = false, features = [ "const_mut_refs" ] }
 
 [features]
-default = [ "platform_virt" ]
-platform_virt = []
+default = [ "platform_verilator_earlgrey" ]
+platform_qemu_virt = []
+platform_verilator_earlgrey = []

--- a/suite/build.rs
+++ b/suite/build.rs
@@ -13,11 +13,17 @@ fn main() {
     let dest_path = Path::new(&out_dir);
     let mut f = File::create(&dest_path.join("memory.x")).expect("Could not create file");
 
-    f.write_all(include_bytes!("memory.x"))
+    #[cfg(feature = "platform_qemu_virt")]
+    let memory_information = include_bytes!("memory/qemu_virt.x");
+    #[cfg(feature = "platform_verilator_earlgrey")]
+    let memory_information = include_bytes!("memory/verilator_earlgrey.x");
+
+    f.write_all(memory_information)
         .expect("Could not write file");
 
     println!("cargo:rustc-link-search={}", dest_path.display());
 
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=memory/qemu_virt.x");
+    println!("cargo:rerun-if-changed=memory/verilator_earlgrey.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/suite/memory/qemu_virt.x
+++ b/suite/memory/qemu_virt.x
@@ -1,4 +1,6 @@
-# memory layout of qemu emulator
+/* 
+*  memory layout of the qemu virt machine
+*/
 
 MEMORY
 {

--- a/suite/memory/verilator_earlgrey.x
+++ b/suite/memory/verilator_earlgrey.x
@@ -1,0 +1,48 @@
+/* memory layout of the opentitan earlgrey chip
+*  For more information see:
+*  https://docs.opentitan.org/hw/top_earlgrey/doc/#register-table
+*/
+
+MEMORY
+{
+  SRAM(w) : ORIGIN = 0x10000000, LENGTH = 0x20000
+  Flash(rx) : ORIGIN = 0x20000000, LENGTH = 0x100000
+}
+
+REGION_ALIAS("REGION_TEXT", Flash);
+REGION_ALIAS("REGION_RODATA", Flash);
+REGION_ALIAS("REGION_DATA", SRAM);
+REGION_ALIAS("REGION_BSS", SRAM);
+REGION_ALIAS("REGION_HEAP", SRAM);
+REGION_ALIAS("REGION_STACK", SRAM);
+
+ENTRY(_start)
+
+/* We have to alter the default riscv-rt linker script because it does not work for the Ibex core */
+SECTIONS
+{
+  /* Custom Opentitan Manifest for the test rom */
+  .text.manifest :
+  {
+    KEEP(*(.text.manifest));
+  } > REGION_TEXT
+
+  /**
+   * Ibex interrupt vector.
+   *
+   * This has to be set up at a 256-byte offset, so that we can use it with
+   * Ibex.
+   */
+  .vectors : ALIGN(256) {
+    KEEP(*(.vectors))
+    *(.vectors)
+  } > REGION_TEXT
+
+  .text.dummy (NOLOAD) :
+  {
+    /* This section is intended to make _stext address work */
+    _stext = .;
+  } > REGION_TEXT
+}
+
+_heap_size = 4K;

--- a/suite/src/main.rs
+++ b/suite/src/main.rs
@@ -15,7 +15,9 @@ use riscv_rt::entry;
 
 extern crate alloc;
 
-fn main() {}
+fn main() {
+    println!("Hello Opentitan World!");
+}
 
 /// First function that is called once riscv_rt finished setting up the rust runtime.
 /// (initialize stack pointer, zero bss, initialize data, ...)

--- a/suite/src/modules/mod.rs
+++ b/suite/src/modules/mod.rs
@@ -49,3 +49,5 @@ pub trait ByteRead {
 
 /// Module for communicating with the Benchmarking-CLI
 pub trait CommunicationModule: core::fmt::Write + Module + ByteRead {}
+
+impl<T> CommunicationModule for T where T: core::fmt::Write + Module + ByteRead {}

--- a/suite/src/modules/opentitan_uart.rs
+++ b/suite/src/modules/opentitan_uart.rs
@@ -1,0 +1,201 @@
+#![allow(dead_code)]
+
+use core::fmt::Write;
+
+use crate::modules::{ByteRead, Module};
+use bitflags::bitflags;
+
+bitflags! {
+    /// Abstract representation of the control registers flags.
+    struct UartCTRL: u32 {
+        const TX_ENABLED = 1 << 0;
+        const RX_ENABLED = 1 << 1;
+    }
+
+    /// Abstract representation of the status registers flags.
+    struct UartSTATUS: u32 {
+        const TX_FULL = 1 << 0;
+        const RX_FULL = 1 << 1;
+        const TX_EMPTY = 1 << 2;
+        const TX_IDLE = 1 << 3;
+        const RX_IDLE = 1 << 4;
+        const RX_EMPTY = 1 << 5;
+    }
+
+    /// Abstract representation of the fifo control registers flags.
+    struct FifoCTRL: u32 {
+        const RX_RESET = 1 << 0;
+        const TX_RESET = 1 << 1;
+    }
+}
+
+// Offset of the control register
+const UART_CTRL_OFFSET: usize = 0x10;
+// Offset of the status register
+const UART_STATUS_OFFSET: usize = 0x14;
+// Offset of the read data register
+const UART_RDATA_OFFSET: usize = 0x18;
+// Offset of the write data register
+const UART_WDATA_OFFSET: usize = 0x1c;
+// Offset of the fifo control register
+const UART_FIFO_CTRL_OFFSET: usize = 0x20;
+// Offset of the fifo status register
+const UART_FIFO_STATUS_OFFSET: usize = 0x24;
+
+/// Offset of the NCO value inside the UartCTRL register
+const UART_NCO_OFFSET: u32 = 16;
+/// Mask of the NCO value
+const UART_NCO_MASK: u64 = 0xffff_ffff_ffff_ffff;
+
+/// Offset of the RX value inside the FifoStatus register
+const UART_RX_LVL_OFFSET: u32 = 16;
+const UART_MAX_RX_LVL: u8 = 32;
+/// Offset of the RX value inside the FifoStatus register
+const UART_TX_LVL_OFFSET: u32 = 0;
+const UART_MAX_TX_LVL: u8 = 32;
+const UART_LVL_MASK: u32 = 0xff_ffff;
+
+/// Uart driver implementation as described by:
+/// https://docs.opentitan.org/hw/ip/uart/doc/
+pub struct OpentitanUart {
+    initialized: bool,
+    baud_rate: u64,
+    clk_hz: u64,
+    base_address: *mut u8,
+}
+
+impl OpentitanUart {
+    /// Creates a new OpentitanUart driver
+    ///
+    /// # Arguments
+    ///
+    /// * `base_address` - A pointer to the MMIO address of the uart device
+    /// * `baud_rate` - The baud rate the uart should be configured with
+    /// * `clk_hz` - Clock speed of the peripheral clock, used to setup the uart device
+    ///
+    /// # Safety:
+    ///  - a valid uart device must be at the base_address
+    ///  - no other uart must use the same base_address
+    pub const unsafe fn new(base_address: *mut u8, baud_rate: u64, clk_hz: u64) -> OpentitanUart {
+        OpentitanUart {
+            initialized: false,
+            baud_rate,
+            clk_hz,
+            base_address,
+        }
+    }
+
+    // Returns pointer to control register
+    unsafe fn _control_reg(&self) -> *mut u32 {
+        self.base_address.add(UART_CTRL_OFFSET) as *mut u32
+    }
+
+    // Returns pointer to status register
+    unsafe fn _status_reg(&self) -> *mut u32 {
+        self.base_address.add(UART_STATUS_OFFSET) as *mut u32
+    }
+
+    // Returns pointer to read data register
+    unsafe fn _read_reg(&self) -> *mut u8 {
+        self.base_address.add(UART_RDATA_OFFSET) as *mut u8
+    }
+
+    // Returns pointer to write data register
+    unsafe fn _write_reg(&self) -> *mut u8 {
+        self.base_address.add(UART_WDATA_OFFSET) as *mut u8
+    }
+
+    // Returns pointer to fifo control register
+    unsafe fn _fifo_control_reg(&self) -> *mut u32 {
+        self.base_address.add(UART_FIFO_CTRL_OFFSET) as *mut u32
+    }
+
+    // Returns pointer to fifo status register
+    unsafe fn _fifo_status_reg(&self) -> *mut u32 {
+        self.base_address.add(UART_FIFO_STATUS_OFFSET) as *mut u32
+    }
+
+    // Uses the fifo control register to signal to the HWIP to reset the fifos
+    unsafe fn reset_fifos(&self) {
+        self._fifo_control_reg()
+            .write_volatile((FifoCTRL::RX_RESET | FifoCTRL::TX_RESET).bits())
+    }
+
+    // Returns the bytes currently in the sending queue
+    unsafe fn get_tx_lvl(&self) -> u8 {
+        ((self._fifo_status_reg().read_volatile() >> UART_TX_LVL_OFFSET) & UART_LVL_MASK) as u8
+    }
+
+    // Returns the bytes currently in the receiving queue
+    unsafe fn get_rx_lvl(&self) -> u8 {
+        ((self._fifo_status_reg().read_volatile() >> UART_RX_LVL_OFFSET) & UART_LVL_MASK) as u8
+    }
+
+    /// Tries to send a byte, fails if the send queue is full
+    ///
+    /// # Arguments
+    ///
+    /// * `val` - the byte that should be sent
+    unsafe fn put(&self, val: u8) -> Result<(), ()> {
+        if self.get_tx_lvl() < UART_MAX_TX_LVL {
+            self._write_reg().write_volatile(val);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// Tries to read a byte, returns none if the receiving queue is empty
+    unsafe fn get(&self) -> Option<u8> {
+        if self.get_rx_lvl() > 0 {
+            Some(self._read_reg().read_volatile())
+        } else {
+            None
+        }
+    }
+}
+
+impl Module for OpentitanUart {
+    unsafe fn init(&mut self) -> Result<(), &'static str> {
+        let nco = ((self.baud_rate << 20) / self.clk_hz) & UART_NCO_MASK;
+
+        // Set BAUD and enable RX & TX
+        self._control_reg().write_volatile(
+            (nco as u32) << UART_NCO_OFFSET | (UartCTRL::RX_ENABLED | UartCTRL::TX_ENABLED).bits(),
+        );
+
+        self.reset_fifos();
+
+        self.initialized = true;
+
+        Ok(())
+    }
+
+    fn initialized(&self) -> bool {
+        self.initialized
+    }
+}
+
+impl Write for OpentitanUart {
+    fn write_str(&mut self, data: &str) -> core::fmt::Result {
+        if !self.initialized {
+            Err(core::fmt::Error)
+        } else {
+            unsafe {
+                for c in data.as_bytes() {
+                    while let Err(_) = self.put(*c) {
+                        core::hint::spin_loop();
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
+impl ByteRead for OpentitanUart {
+    fn read_byte(&self) -> Option<u8> {
+        unsafe { self.get() }
+    }
+}

--- a/suite/src/modules/uart16550.rs
+++ b/suite/src/modules/uart16550.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write;
 
-use crate::modules::{ByteRead, CommunicationModule, Module};
+use crate::modules::{ByteRead, Module};
 use bitflags::bitflags;
 
 bitflags! {
@@ -110,5 +110,3 @@ impl ByteRead for Uart16550 {
         }
     }
 }
-
-impl CommunicationModule for Uart16550 {}

--- a/suite/src/platform/earlgrey/ibex_start.S
+++ b/suite/src/platform/earlgrey/ibex_start.S
@@ -1,0 +1,81 @@
+/**
+ * ROM_EXT Interrupt Vector, adapted from opentitan/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+ */
+  .section .vectors, "ax"
+  
+  .option push
+  .option norvc
+  .option norelax
+
+  /**
+   * Ibex-compatible interrupt vector.
+   *
+   * For more information see:
+   * https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+   */
+  .balign 256
+  .global _interrupt_vector
+  .type _interrupt_vector, @function
+_interrupt_vector:
+  // Exception and User Software Interrupt Handler.
+  unimp
+  // Supervisor Software Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine Software Interrupt Handler.
+  unimp
+
+  // User Timer Interrupt Handler.
+  unimp
+  // Supervisor Timer Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine Timer Interrupt Handler.
+  unimp
+
+  // User External Interrupt Handler.
+  unimp
+  // Supervisor External Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine External Interrupt Handler.
+  unimp
+
+  // Reserved.
+  unimp
+  unimp
+  unimp
+  unimp
+
+  // On Ibex interrupt ids 16-30 are for "fast" interrupts.
+  .rept 15
+  unimp
+  .endr
+
+  // On Ibex interrupt id 31 is for non-maskable interrupts.
+  unimp
+  .size _interrupt_vector, .-_interrupt_vector
+
+  .option pop
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Opentitan Manifest information
+ *
+ * For more information see:
+ * https://docs.opentitan.org/sw/device/silicon_creator/rom_ext/docs/manifest/
+ */
+
+  .section .text.manifest
+
+  .extern _start
+
+_opentitan_manifest:
+
+  // For the testing ROM only the entry_point is relevant so ignore the prior fields 
+  .skip 892
+  .word _start

--- a/suite/src/platform/earlgrey/mod.rs
+++ b/suite/src/platform/earlgrey/mod.rs
@@ -1,0 +1,46 @@
+use core::arch::global_asm;
+
+use crate::println;
+
+use super::Platform;
+
+#[path = "../../modules/opentitan_uart.rs"]
+mod opentitan_uart;
+
+// Opentitan requires a manifest and custom interrupt vector,
+// these are realized in ibex_start.S and included here.
+global_asm!(include_str!("ibex_start.S"));
+
+// Note: clk_hz & baud_rate according to sw/device/lib/arch/device_sim_verilator.c
+static mut UART0: opentitan_uart::OpentitanUart =
+    unsafe { opentitan_uart::OpentitanUart::new(0x4000_0000 as *mut u8, 7200, 125_000) };
+
+/// EarlGrey platform according to the Opentitan specification:
+///
+/// https://docs.opentitan.org/hw/top_earlgrey/doc/
+pub struct EarlGreyPlatform;
+
+impl Platform for EarlGreyPlatform {
+    unsafe fn get_communication_module(
+        &self,
+    ) -> &'static mut dyn crate::modules::CommunicationModule {
+        // Safety:
+        // there possibly exist multiple mutable references to UART0
+        // but the responsibility to ensure correctness is delegated
+        // to the caller of this function
+        &mut UART0
+    }
+
+    fn suspend(&self, _code: u32) -> ! {
+        // If this is a successful suspension, try printing it to the user
+        if _code == 0 {
+            println!("Successfully finished executing, going to sleep!")
+        }
+
+        loop {
+            unsafe {
+                riscv::asm::wfi();
+            }
+        }
+    }
+}

--- a/suite/src/platform/mod.rs
+++ b/suite/src/platform/mod.rs
@@ -1,12 +1,20 @@
 use crate::modules::CommunicationModule;
 
-#[cfg(feature = "platform_virt")]
+#[cfg(feature = "platform_verilator_earlgrey")]
+mod earlgrey;
+#[cfg(feature = "platform_qemu_virt")]
 mod virt;
 
 /// Returns the platform the suite was compiled for.
 pub fn current() -> impl Platform {
-    #[cfg(feature = "platform_virt")]
-    virt::VirtPlatform
+    #[cfg(feature = "platform_qemu_virt")]
+    {
+        virt::VirtPlatform
+    }
+    #[cfg(feature = "platform_verilator_earlgrey")]
+    {
+        earlgrey::EarlGreyPlatform
+    }
 }
 
 /// A platform represents the underlying layer on which the suite runs.

--- a/suite/src/runtime.rs
+++ b/suite/src/runtime.rs
@@ -86,10 +86,12 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
     () => (unsafe {
+        #[allow(unused_imports)]
         use crate::platform::Platform;
         writeln!($crate::platform::current().get_communication_module()).unwrap();
     });
     ($($arg:tt)*) => (unsafe {
+        #[allow(unused_imports)]
         use crate::platform::Platform;
         writeln!($crate::platform::current().get_communication_module(), $($arg)*).unwrap();
     });
@@ -100,6 +102,7 @@ macro_rules! println {
 macro_rules! readln {
     () => {
         unsafe {
+            #[allow(unused_imports)]
             use crate::platform::Platform;
             $crate::platform::current()
                 .get_communication_module()


### PR DESCRIPTION
This pull request builds on #1 and modifies it so that it runs on the opentitan [Earl Grey chip](https://docs.opentitan.org/hw/top_earlgrey/doc/) when simulating it using verilator.

Current progress:

- [x] create verilator_earlgrey platform, with custom Ibex startup code & dummy manifest
- [x] allow for different link scripts depending on target_platform
- [x] create custom link script for verilator_earlgrey platform
- [x] write module for [opentitan uart](https://docs.opentitan.org/hw/ip/uart/doc/)
- [x] check heap allocations work as expected
- [x] simplify verilator_earlgrey platform workflow

## How to run currently

### Using the default.nix of the opentitan repo, run these instructions inside the Opentitan-Repo, to build the required artifacts (required once):

1. [Build the earlgrey chip for verilator](https://docs.opentitan.org/doc/getting_started/setup_verilator/#simulating-a-design-with-verilator)
```console
ci/scripts/build-chip-verilator.sh earlgrey
```

2. The suite depends on software implementing the opentitan boot process, therefore the test_rom and the opt_img need to be built.
```console
ninja -C build-out sw/device/lib/testing/test_rom/test_rom_export_sim_verilator
ninja -C build-out sw/device/otp_img/otp_img_export_sim_verilator
```

3. Export the artifacts as environment variables:
```console
export VERILATOR_SIM=$(realpath build-bin/hw/top_earlgrey/Vchip_earlgrey_verilator)
export VERILATOR_ROM=$(realpath build-bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem)
export VERILATOR_OTP=$(realpath build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem)
```

### The Suite can now be simulated using `cargo run-verilator`

During the simulation the rom & the suite output using the uart0. 
One way to read what was sent is reading the `uart0.log` or using cat to read directly from the pts that is set up by verilator.
On success the output should be:
```
I00000 test_rom.c:67] Version:    opentitan-earlgrey_silver_release_v5-4904-g7e3037a30
Build Date: XXXX-XX-XX, XX:XX:XX

I00001 test_rom.c:88] Test ROM complete, jumping to flash!
Hello Opentitan World!
Successfully finished executing, going to sleep!
```
The last two messages are sent by the suite, which means it was correctly linked, loaded and correctly configured & used the uart to output these lines.