### PR TITLE
implement hmac module

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@ let
       "llvm-tools-preview"
       "rust-analyzer-preview"
       "rustfmt-preview"
+      "clippy-preview"
     ];
   };
 in

--- a/suite/.cargo/config.toml
+++ b/suite/.cargo/config.toml
@@ -11,6 +11,10 @@ target = "riscv32imc-unknown-none-elf"
 
 [alias]
 run-qemu = "run --no-default-features --features platform_qemu_virt -- -q"
+run-qemu-opt = "run --no-default-features --features platform_qemu_virt --release -- -q"
 test-qemu = "test --no-default-features --features platform_qemu_virt -- -q"
+test-qemu-opt = "test --no-default-features --features platform_qemu_virt --release -- -q"
 run-verilator = "run --no-default-features --features platform_verilator_earlgrey -- -v"
+run-verilator-opt = "run --no-default-features --features platform_verilator_earlgrey --release -- -v"
 test-verilator = "test --no-default-features --features platform_verilator_earlgrey -- -v"
+test-verilator-opt = "test --no-default-features --features platform_verilator_earlgrey --release -- -v"

--- a/suite/src/benchmark.rs
+++ b/suite/src/benchmark.rs
@@ -1,0 +1,84 @@
+use core::arch::asm;
+
+/// Returns the machine cycle counter
+///
+/// Adapted from Fig. 10.1 on Page 61 of ["Volume I: RISC-V Unprivileged ISA V20191213"]
+/// (https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf)
+///
+/// The `rdcycle x` and `rdcycleh x` instructions have been replaced by
+/// `csrr x, mcycle` and `csrr x, mcycleh` respectively, so this function can be called
+/// while being in machine mode.
+#[inline]
+pub fn get_cycle() -> u64 {
+    let counter_lo: u32;
+    let counter_hi: u32;
+
+    unsafe {
+        asm!(
+            "1: csrr {hi_old}, mcycleh",
+            "csrr {lo}, mcycle",
+            "csrr {hi}, mcycleh",
+            "bne {hi_old}, {hi}, 1b",
+            hi_old = out(reg) _,
+            lo = out(reg) counter_lo,
+            hi = out(reg) counter_hi
+        );
+    }
+    ((counter_hi as u64) << 32u64) + counter_lo as u64
+}
+
+pub mod examples {
+
+    use crate::platform::{self, Platform};
+
+    /// Runs an example benchmark for the SHA256 module
+    ///
+    /// # Arguments
+    /// * `n` - the number of times the benchmark should be run
+    pub fn sha256_benchmark(n: u32) {
+        if let Some(hmac_module) = platform::current().get_sha256_module() {
+            println!("initialization, computation, reading_output");
+
+            let input = [
+                0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0,
+                0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c,
+                0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc,
+                0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748,
+                0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d,
+                0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb,
+                0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198,
+                0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119,
+                0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0,
+                0x14b81119,
+            ];
+
+            for _ in 0..n {
+                let mut output = [0u32; 8];
+
+                let cycle1 = super::get_cycle();
+                hmac_module.init_sha256();
+                let cycle2 = super::get_cycle();
+                hmac_module.write_input(&input);
+                hmac_module.wait_for_completion();
+                let cycle3 = super::get_cycle();
+                hmac_module.read_digest(&mut output);
+                let cycle4 = super::get_cycle();
+
+                assert_eq!(
+                    output,
+                    [
+                        // precomputed by sha2 crate
+                        0xa24ef743, 0xed238e92, 0x8f5fe495, 0x7959a1fa, 0x06b1d250, 0x147ed98d,
+                        0xd817e3b2, 0xb32854ae,
+                    ]
+                );
+
+                let initialization = cycle2 - cycle1;
+                let computation = cycle3 - cycle2;
+                let reading_output = cycle4 - cycle3;
+
+                println!("{initialization}, {computation}, {reading_output}");
+            }
+        }
+    }
+}

--- a/suite/src/main.rs
+++ b/suite/src/main.rs
@@ -9,6 +9,7 @@ mod modules;
 mod platform;
 #[macro_use]
 mod runtime;
+mod benchmark;
 
 use platform::Platform;
 use riscv_rt::entry;
@@ -17,6 +18,8 @@ extern crate alloc;
 
 fn main() {
     println!("Hello Opentitan World!");
+
+    benchmark::examples::sha256_benchmark(8);
 }
 
 /// First function that is called once riscv_rt finished setting up the rust runtime.

--- a/suite/src/modules/mod.rs
+++ b/suite/src/modules/mod.rs
@@ -5,6 +5,10 @@
 //!
 //! This file contains traits for all supported modules.
 //! This folder includes module implementations that can be used and potentially reused by platforms.
+use core::{
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
 
 use alloc::string::String;
 
@@ -51,3 +55,123 @@ pub trait ByteRead {
 pub trait CommunicationModule: core::fmt::Write + Module + ByteRead {}
 
 impl<T> CommunicationModule for T where T: core::fmt::Write + Module + ByteRead {}
+
+/// Module for performing SHA265 hash computation
+pub trait SHA256Module: Module {
+    /// Setup the Module for SHA256 computation
+    fn init_sha256(&self);
+
+    /// Input data into the module, over which the sha hash should be computed
+    /// This function accepts &[u32] for performance reasons.
+    /// If the data is present as &[u8] try transmuting it to &[u32].
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - the data to compute the hash of
+    fn write_input(&self, data: &[u32]);
+
+    /// Blocks until the SHA256 module completed computation
+    fn wait_for_completion(&self);
+
+    /// Reads the output of the SHA256 module
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - the buffer into which the digest should be read
+    fn read_digest(&self, buffer: &mut [u32; 8]);
+}
+
+/// Wrapper for a pointer to a Module
+///
+/// This wrapper is used as a guarantee that the underlying
+/// pointer is valid and to have cleaner return values.
+///
+/// Automatic dereferencing is implemented, so the reference can be used like the module.
+pub struct ModuleRef<T: Module + ?Sized>(NonNull<T>);
+
+impl<T: Module + ?Sized> ModuleRef<T> {
+    /// Safety:
+    ///  - only call with a valid pointer
+    ///  - the pointer has to stay valid
+    #[allow(dead_code)]
+    pub unsafe fn new(module: *mut T) -> ModuleRef<T> {
+        ModuleRef(NonNull::new_unchecked(module))
+    }
+}
+
+impl<T: Module + ?Sized> Deref for ModuleRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T: Module + ?Sized> DerefMut for ModuleRef<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.0.as_mut() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{mark_test_as_skipped, platform, platform::Platform};
+
+    #[test_case]
+    fn sha256_digest_is_correct1() {
+        if let Some(hmac_module) = platform::current().get_sha256_module() {
+            let input = [0u32; 1];
+            let mut output = [0u32; 8];
+
+            hmac_module.init_sha256();
+            hmac_module.write_input(&input);
+            hmac_module.wait_for_completion();
+            hmac_module.read_digest(&mut output);
+
+            assert_eq!(
+                output,
+                [
+                    // Precomputed value by sha2 crate
+                    0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c,
+                    0xe80524c0, 0x14b81119,
+                ]
+            )
+        } else {
+            mark_test_as_skipped!()
+        }
+    }
+
+    #[test_case]
+    fn sha256_digest_is_correct2() {
+        if let Some(hmac_module) = platform::current().get_sha256_module() {
+            let input = [
+                0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0,
+                0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c,
+                0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc,
+                0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748,
+                0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb, 0x4057192d,
+                0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198, 0x04a92fdb,
+                0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119, 0xdf3f6198,
+                0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0, 0x14b81119,
+                0xdf3f6198, 0x04a92fdb, 0x4057192d, 0xc43dd748, 0xea778adc, 0x52bc498c, 0xe80524c0,
+            ];
+            let mut output = [0u32; 8];
+
+            hmac_module.init_sha256();
+            hmac_module.write_input(&input);
+            hmac_module.wait_for_completion();
+            hmac_module.read_digest(&mut output);
+
+            assert_eq!(
+                output,
+                [
+                    // Precomputed value by sha2 crate
+                    0x572ad168, 0x273d0dce, 0x05a098a5, 0x5509de23, 0x70110f07, 0x0b57a5ed,
+                    0x910bf83c, 0xbc6c1496,
+                ]
+            )
+        } else {
+            mark_test_as_skipped!()
+        }
+    }
+}

--- a/suite/src/modules/opentitan_hmac.rs
+++ b/suite/src/modules/opentitan_hmac.rs
@@ -1,0 +1,167 @@
+#![allow(dead_code)]
+
+use crate::modules::{Module, SHA256Module};
+use bitflags::bitflags;
+
+bitflags! {
+    /// Abstract representation of the config registers flags.
+    struct HmacCFG: u32 {
+        const HMAC_ENABLED = 1 << 0;
+        const SHA_ENABLED = 1 << 1;
+        /// If set the input is interpreted in little endian, otherwise big endian
+        const ENDIAN_SWAPPED = 1 << 2;
+        /// If set the output is in big endian, otherwise little endian
+        const DIGEST_ENDIAN_SWAPPED = 1 << 3;
+    }
+
+    /// Abstract representation of the command registers flags.
+    struct HmacCMD: u32 {
+        const HASH_START = 1 << 0;
+        const HASH_PROCESS = 1 << 1;
+    }
+
+    /// Abstract representation of the status registers flags.
+    struct HmacSTATUS: u32 {
+        const FIFO_EMPTY = 1 << 0;
+        const FIFO_FULL = 1 << 1;
+    }
+
+    /// Abstract representation of the interrupt state registers flags.
+    struct HmacINTRSTATE: u32 {
+        const HMAC_DONE = 1 << 0;
+        const FIFO_EMPTY = 1 << 1;
+        const HMAC_ERR = 1 << 2;
+    }
+}
+
+/// Offset of the interrupt state register
+const HMAC_INTR_STATE_OFFSET: usize = 0x0;
+/// Offset of the configuration register
+const HMAC_CFG_OFFSET: usize = 0x10;
+/// Offset of the command register
+const HMAC_CMD_OFFSET: usize = 0x14;
+/// Offset of the status register
+const HMAC_STATUS_OFFSET: usize = 0x18;
+/// Offset of the digest register
+///
+/// Digest can be used like an [u32; 8] residing at this offset
+const HMAC_DIGEST_OFFSET: usize = 0x44;
+/// Offset of the message register
+const HMAC_MSG_OFFSET: usize = 0x800;
+
+/// HMAC driver implementation as described by:
+/// https://docs.opentitan.org/hw/ip/hmac/doc/
+pub struct OpentitanHMAC {
+    initialized: bool,
+    base_address: *mut u8,
+}
+
+impl OpentitanHMAC {
+    /// Creates a new OpentitanHMAC driver
+    ///
+    /// # Arguments
+    ///
+    /// * `base_address` - A pointer to the MMIO address of the hmac device
+    ///
+    /// # Safety:
+    ///  - a valid hmac device must be at the base_address
+    ///  - no other hmac must use the same base_address
+    pub const unsafe fn new(base_address: *mut u8) -> OpentitanHMAC {
+        OpentitanHMAC {
+            initialized: true,
+            base_address,
+        }
+    }
+
+    /// Returns pointer to interrupt state register
+    #[inline]
+    unsafe fn _interrupt_state_reg(&self) -> *mut u32 {
+        self.base_address.add(HMAC_INTR_STATE_OFFSET) as *mut u32
+    }
+
+    /// Returns pointer to configuration register
+    #[inline]
+    unsafe fn _config_reg(&self) -> *mut u32 {
+        self.base_address.add(HMAC_CFG_OFFSET) as *mut u32
+    }
+
+    /// Returns pointer to command register
+    #[inline]
+    unsafe fn _command_reg(&self) -> *mut u32 {
+        self.base_address.add(HMAC_CMD_OFFSET) as *mut u32
+    }
+
+    /// Returns pointer to status register
+    #[inline]
+    unsafe fn _status_reg(&self) -> *mut u32 {
+        self.base_address.add(HMAC_STATUS_OFFSET) as *mut u32
+    }
+
+    /// Returns pointer to digest register
+    #[inline]
+    unsafe fn _digest(&self) -> *mut [u32; 8] {
+        self.base_address.add(HMAC_DIGEST_OFFSET) as *mut [u32; 8]
+    }
+
+    /// Returns pointer to message register
+    #[inline]
+    unsafe fn _msg_reg(&self) -> *mut u32 {
+        self.base_address.add(HMAC_MSG_OFFSET) as *mut u32
+    }
+}
+
+impl Module for OpentitanHMAC {
+    unsafe fn init(&mut self) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn initialized(&self) -> bool {
+        self.initialized
+    }
+}
+
+impl SHA256Module for OpentitanHMAC {
+    fn init_sha256(&self) {
+        unsafe {
+            self._config_reg()
+                .write_volatile(HmacCFG::SHA_ENABLED.bits())
+        }
+    }
+
+    fn write_input(&self, data: &[u32]) {
+        unsafe {
+            self._command_reg()
+                .write_volatile(HmacCMD::HASH_START.bits());
+
+            for value in data {
+                while HmacSTATUS::from_bits_unchecked(self._status_reg().read_volatile())
+                    .contains(HmacSTATUS::FIFO_FULL)
+                {
+                    core::hint::spin_loop()
+                }
+
+                self._msg_reg().write_volatile(*value);
+            }
+        }
+    }
+
+    fn wait_for_completion(&self) {
+        unsafe {
+            self._command_reg()
+                .write_volatile(HmacCMD::HASH_PROCESS.bits());
+
+            while !HmacINTRSTATE::from_bits_unchecked(self._interrupt_state_reg().read_volatile())
+                .contains(HmacINTRSTATE::HMAC_DONE)
+            {
+                core::hint::spin_loop()
+            }
+
+            self._interrupt_state_reg()
+                .write_volatile(HmacINTRSTATE::HMAC_DONE.bits());
+        }
+    }
+
+    fn read_digest(&self, buffer: &mut [u32; 8]) {
+        unsafe { buffer.copy_from_slice(&self._digest().read_volatile()) }
+    }
+}

--- a/suite/src/platform/mod.rs
+++ b/suite/src/platform/mod.rs
@@ -1,4 +1,4 @@
-use crate::modules::CommunicationModule;
+use crate::modules::{CommunicationModule, ModuleRef, SHA256Module};
 
 #[cfg(feature = "platform_verilator_earlgrey")]
 mod earlgrey;
@@ -29,6 +29,11 @@ pub trait Platform {
     ///  - this module should only be used through the macros provided by `runtime.rs`
     ///  - calling the function more than once might invalidate previous references
     unsafe fn get_communication_module(&self) -> &'static mut dyn CommunicationModule;
+
+    /// Returns the platforms SHA256 module if one is present.
+    fn get_sha256_module(&self) -> Option<ModuleRef<dyn SHA256Module>> {
+        None
+    }
 
     /// Signals the platform that the suite finished executing.
     /// What should happen when this function is called is defined by the platform.


### PR DESCRIPTION
This pull request builds on #2 and adds a module for the [opentitan hmac HWIP](https://docs.opentitan.org/hw/ip/hmac/doc/).

## Current progress:

- [x] implement SHA256 part of hmac module
- [x] implement reading of cycle count  
- [x] fix outstanding bugs 

## Outstanding bugs:

[fixed] When compiling using rust's release mode, the resulting binary does not behave in the same way. Preliminary tests pass on debug builds (standard) but not on optimized builds.

## Preliminary results:

Using verilator to simulate the architecture, and running the suite compiled in release mode yields the following output:
```
Sha256 example-runtime analysis of 2048 bits:
initialization: 33 cycles
writing_input:  1125 cycles
computation*:   162 cycles
reading_output: 56 cycles
```
Note that the hmac HWIP performs partial computation while the input is written.  \
Also there are busy wait loops during writing of the input, that are used to wait for the hmac HWIP to consume the current data, so the rest of the input can be written. \
Hence the distinction between `writing_input` and `computation` is not accurate.
