### PR TITLE
Rename libudev to udev in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     qemu
     rustToolchain
     pkg-config
-    libudev
+    udev
   ];
 }


### PR DESCRIPTION
This is required because the reproduce.py script otherwise fails.