### PR TITLE
add opentitans ecdsa library

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ The code of the benchmarking suite uses two main abstractions:
 
 ### Manual Usage
 
-The benchmarking suite can be built using `cargo build`.
+First set the `OPENTITAN_LIBS_PATH` environment variable to a folder containing the required opentitan libraries.
+The following are the libraries that are required, they are also listed in the `reproduce.py` script:
+* libsw_lib_crypto_ecdsa_p256.a
+* libp256_ecdsa.a
+* libsw_lib_crypto_otbn_util.a
+* libsw_lib_crypto_otbn.a
+
+The benchmarking suite can then be built using `cargo build`.
 
 **Running/Testing using the Qemu emulator:**
 

--- a/benchmarks/raw_example_ecdsa.bench
+++ b/benchmarks/raw_example_ecdsa.bench
@@ -1,0 +1,6 @@
+# This file contains serializations of messages that should be sent to the suite.
+# For more information, like a description of all messages, check the common crate.
+
+# This does not finish in verilator because the OTBN HWIP is always "busy"
+# TODO: Test if everything works on FPGA
+# {"Benchmark":["ExampleECDSA",3]}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -41,6 +41,7 @@ pub enum BenchmarkInfo {
     ExampleSHA256,
     ExampleAES256,
     ExampleRNG,
+    ExampleECDSA,
 }
 
 /// Messages sent from the Suite to the CLI
@@ -78,6 +79,10 @@ pub enum BenchmarkResult {
     ExampleRNG {
         initialization: u64,
         generation: u64,
+    },
+    ExampleECDSA {
+        signing: u64,
+        verifying: u64,
     },
 }
 

--- a/suite/build.rs
+++ b/suite/build.rs
@@ -23,6 +23,10 @@ fn main() {
 
     println!("cargo:rustc-link-search={}", dest_path.display());
 
+    let ot_libs = env::var("OPENTITAN_LIBS_PATH")
+        .expect("Missing opentitan libraries, OPENTITAN_LIBS_PATH environment variable");
+    println!("cargo:rustc-link-search={}", ot_libs);
+
     println!("cargo:rerun-if-changed=memory/qemu_virt.x");
     println!("cargo:rerun-if-changed=memory/verilator_earlgrey.x");
     println!("cargo:rerun-if-changed=build.rs");

--- a/suite/src/cmd.rs
+++ b/suite/src/cmd.rs
@@ -27,6 +27,7 @@ pub fn run_cmd(cmd: IncomingMessage) -> Option<OutgoingMessage> {
                     benchmark_common::BenchmarkInfo::ExampleSHA256 => examples::sha256_benchmark(),
                     benchmark_common::BenchmarkInfo::ExampleAES256 => examples::aes256_benchmark(),
                     benchmark_common::BenchmarkInfo::ExampleRNG => examples::rng_benchmark(),
+                    benchmark_common::BenchmarkInfo::ExampleECDSA => examples::ecdsa_benchmark(),
                 };
 
                 if let Some(result) = result {

--- a/suite/src/libs/ecdsa.rs
+++ b/suite/src/libs/ecdsa.rs
@@ -1,0 +1,110 @@
+//! FFI Code for the opentitan ecdsa library
+#![allow(dead_code)]
+
+use core::mem;
+
+use super::otbn::otbn_error_t;
+
+/// This is a boolean type for use in hardened contexts.
+/// The intention is that this is used instead of a bool, where a
+/// higher hamming distance is required between the truthy and the falsey value.
+/// The values below were chosen at random, with some specific restrictions. They
+/// have a Hamming Distance of 8, and they are 11-bit values so they can be
+/// materialized with a single instruction on RISC-V. They are also specifically
+/// not the complement of each other.
+#[repr(C)]
+pub enum hardened_bool_t {
+    /// The truthy value, expected to be used like #true.
+    HardenedBoolTrue = 0x739,
+    /// The falsey value, expected to be used like #false.
+    HardenedBoolFalse = 0x1d4,
+    /// Custom invalid value for initialization.
+    HardenedBoolInvalid = 0,
+}
+
+/// Length of a P-256 curve point coordinate in bits (integer modulo the "p"
+/// parameter, see FIPS 186-4 section D.1.2.3)
+const K_P256_COORD_NUM_BITS: usize = 256;
+
+/// Length of a P-256 curve point coordinate in words
+const K_P256_COORD_NUM_WORDS: usize = K_P256_COORD_NUM_BITS / (mem::size_of::<u32>() * 8);
+
+/// Length of a number modulo the P-256 "n" parameter (see FIPS 186-4 section D.1.2.3) in bits
+const K_P256_SCALAR_NUM_BITS: usize = 256;
+
+/// Length of a number modulo the P-256 "n" parameter in words
+const K_P256_SCALAR_NUM_WORDS: usize = K_P256_SCALAR_NUM_BITS / (mem::size_of::<u32>() * 8);
+
+/// Length of the message digest in bits
+const K_P256_MESSAGE_DIGEST_NUM_BITS: usize = 256;
+
+/// A type that holds an ECDSA/P-256 signature.
+///
+/// The signature consists of two integers r and s, computed modulo n.
+#[repr(C)]
+pub struct ecdsa_p256_signature_t {
+    pub r: [u32; K_P256_SCALAR_NUM_WORDS],
+    pub s: [u32; K_P256_SCALAR_NUM_WORDS],
+}
+
+/// A type that holds an ECDSA/P-256 private key.
+///
+/// The private key consists of a single integer d, computed modulo n.
+#[repr(C)]
+pub struct ecdsa_p256_private_key_t {
+    pub d: [u32; K_P256_SCALAR_NUM_WORDS],
+}
+
+/// A type that holds an ECDSA/P-256 public key.
+///
+/// The public key is a point Q on the p256 curve, consisting of two coordinates
+/// x and y computed modulo p.
+#[repr(C)]
+pub struct ecdsa_p256_public_key_t {
+    pub x: [u32; K_P256_COORD_NUM_WORDS],
+    pub y: [u32; K_P256_COORD_NUM_WORDS],
+}
+
+/// A type that holds an ECDSA/P-256 message digest.
+///
+/// The message digest is expected to already be transformed into an integer
+/// h = H(msg) mod n, where H is the hash function.
+#[repr(C)]
+pub struct ecdsa_p256_message_digest_t {
+    pub h: [u32; K_P256_SCALAR_NUM_WORDS],
+}
+
+#[link(name = "sw_lib_crypto_ecdsa_p256")]
+extern "C" {
+
+    /// Generates an ECDSA/P-256 signature.
+    ///
+    /// # Arguments
+    ///
+    /// * `message_digest` - Digest of the message to sign.
+    /// * `private_key` - Key to sign the message with.
+    /// * `result` - Buffer in which to store the generated signature.
+    pub fn ecdsa_p256_sign(
+        digest: *const ecdsa_p256_message_digest_t,
+        private_key: *const ecdsa_p256_private_key_t,
+        result: *mut ecdsa_p256_signature_t,
+    ) -> otbn_error_t;
+
+    /// Verifies an ECDSA/P-256 signature.
+    ///
+    /// # Arguments
+    ///
+    /// * `signature` - Signature to be verified.
+    /// * `message_digest` - Digest of the message to check the signature against.
+    /// * `public_key` - Key to check the signature against.
+    /// * `result` - Buffer in which to store output (true iff signature is valid)
+    pub fn ecdsa_p256_verify(
+        signature: *const ecdsa_p256_signature_t,
+        digest: *const ecdsa_p256_message_digest_t,
+        public_key: *const ecdsa_p256_public_key_t,
+        result: *mut hardened_bool_t,
+    ) -> otbn_error_t;
+}
+
+#[link(name = "p256_ecdsa")]
+extern "C" {}

--- a/suite/src/libs/mod.rs
+++ b/suite/src/libs/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "platform_verilator_earlgrey")]
+pub mod ecdsa;
+#[cfg(feature = "platform_verilator_earlgrey")]
+pub mod otbn;

--- a/suite/src/libs/otbn.rs
+++ b/suite/src/libs/otbn.rs
@@ -1,0 +1,22 @@
+//! FFI Code for the opentitan big number library
+#![allow(dead_code)]
+
+#[repr(C)]
+pub enum otbn_error_t {
+    /// No errors.
+    OtbnErrorOk = 0,
+    /// Invalid argument provided to OTBN interface function.
+    OtbnErrorInvalidArgument = 1,
+    /// Invalid offset provided.
+    OtbnErrorBadOffsetLen = 2,
+    /// OTBN internal error; use otbn_get_err_bits for specific error codes.
+    OtbnErrorExecutionFailed = 3,
+    /// Attempt to interact with OTBN while it was unavailable.
+    OtbnErrorUnavailable = 4,
+}
+
+#[link(name = "sw_lib_crypto_otbn")]
+extern "C" {}
+
+#[link(name = "sw_lib_crypto_otbn_util")]
+extern "C" {}

--- a/suite/src/main.rs
+++ b/suite/src/main.rs
@@ -9,6 +9,7 @@
 mod runtime;
 mod benchmark;
 mod cmd;
+mod libs;
 mod modules;
 mod platform;
 


### PR DESCRIPTION
This PR adds support for the opentitan ecdsa library, this lib allows signing and verification using ecdsa.
The library used the open titan big number accelerator.

I was not able to test if everything works, because on verilator the OTBN accelerator is always "busy" and thus the library calls do not return.