### PR TITLE
make hardened_bool_t comparable

### DIFF
--- a/suite/src/libs/ecdsa.rs
+++ b/suite/src/libs/ecdsa.rs
@@ -13,6 +13,7 @@ use super::otbn::otbn_error_t;
 /// materialized with a single instruction on RISC-V. They are also specifically
 /// not the complement of each other.
 #[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum hardened_bool_t {
     /// The truthy value, expected to be used like #true.
     HardenedBoolTrue = 0x739,


### PR DESCRIPTION
This should fix a compilation error because the enum was not comparable & not printable, which is required for assertions.